### PR TITLE
I have removed `swagger-ui-express` to disable the Swagger UI and add…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,7 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
-        "rxjs": "^7.8.1",
-        "swagger-ui-express": "^5.0.1"
+        "rxjs": "^7.8.1"
       },
       "devDependencies": {
         "@compodoc/compodoc": "^1.1.26",
@@ -14646,21 +14645,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"
-      }
-    },
-    "node_modules/swagger-ui-express": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
-      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
-      "license": "MIT",
-      "dependencies": {
-        "swagger-ui-dist": ">=5.0.0"
-      },
-      "engines": {
-        "node": ">= v0.10.32"
-      },
-      "peerDependencies": {
-        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1",
-    "swagger-ui-express": "^5.0.1"
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.26",

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from './app.module';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { Logger } from '@nestjs/common';
 import { NestExpressApplication } from '@nestjs/platform-express';
+import { apiReference } from '@scalar/nestjs-api-reference';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -17,9 +18,15 @@ async function bootstrap() {
 
   const document = SwaggerModule.createDocument(app, config);
 
-  // Servir Swagger UI em /api
-  SwaggerModule.setup('api', app, document);
-
+  // Add Scalar middleware
+  app.use(
+    '/reference',
+    apiReference({
+      spec: {
+        content: document,
+      },
+    }),
+  );
 
   await app.listen(port);
   Logger.log(`Application is running on: http://localhost:${port}`);


### PR DESCRIPTION
…ed `@scalar/nestjs-api-reference` to serve the Scalar documentation at the `/reference` endpoint.

I updated the `main.ts` file to integrate Scalar, which uses the existing OpenAPI document generated by `@nestjs/swagger`. I've kept the `@nestjs/swagger` package, as it's necessary for generating the OpenAPI specification that Scalar consumes.