### PR TITLE
fix: mock PrismaService in app e2e test to resolve connection error

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -3,14 +3,28 @@ import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 
 import { AppModule } from './../src/app.module';
+import { PrismaService } from '../src/core/config/prisma.service';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;
 
+  const prismaService = {
+    $connect: jest.fn(),
+    log: {
+      create: jest.fn().mockResolvedValue({}),
+    },
+    user: {
+      findUnique: jest.fn().mockResolvedValue(null),
+    },
+  };
+
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
-    }).compile();
+    })
+      .overrideProvider(PrismaService)
+      .useValue(prismaService)
+      .compile();
 
     app = moduleFixture.createNestApplication();
     await app.init();


### PR DESCRIPTION
The end-to-end test for the root endpoint was failing due to database connection errors during AppModule initialization. This change mocks the PrismaService (specifically $connect and log.create) to allow the app to start without a running database, enabling verification of the expected root endpoint response (HTML content). This addresses the issue where the test could not verify the correct response due to infrastructure failure.

---
*PR created automatically by Jules for task [12341939562222615034](https://jules.google.com/task/12341939562222615034) started by @lucascampos42*