### PR TITLE
perf: implement pagination for log retrieval

### DIFF
--- a/src/application/log/log.controller.ts
+++ b/src/application/log/log.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Controller, Get, UseGuards, Query } from '@nestjs/common';
 import { LogService } from './log.service';
 import { RolesGuard } from '../../core/guards/roles.guard';
 import { Roles } from '../../core/decorators/roles.decorator';
@@ -11,7 +11,9 @@ export class LogController {
 
   @Get()
   @Roles(Role.ADMIN)
-  findAll() {
-    return this.logService.findAll();
+  findAll(@Query('page') page = '1', @Query('limit') limit = '20') {
+    const pageNum = Math.max(parseInt(page as string, 10) || 1, 1);
+    const limitNum = Math.min(Math.max(parseInt(limit as string, 10) || 20, 1), 100);
+    return this.logService.findAllPaged({ page: pageNum, limit: limitNum });
   }
 }

--- a/src/application/log/log.service.spec.ts
+++ b/src/application/log/log.service.spec.ts
@@ -7,8 +7,10 @@ import { Log, Prisma } from '@prisma/client';
 const mockPrismaService = {
   log: {
     create: jest.fn(),
+    count: jest.fn(),
     findMany: jest.fn(),
   },
+  $transaction: jest.fn(),
 };
 
 describe('LogService', () => {
@@ -28,6 +30,8 @@ describe('LogService', () => {
 
     service = module.get<LogService>(LogService);
     prisma = module.get<PrismaService>(PrismaService);
+
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
@@ -35,7 +39,7 @@ describe('LogService', () => {
   });
 
   describe('createLog', () => {
-    it('should create AuthRequest.ts new log', async () => {
+    it('should create a new log', async () => {
       const logData: Prisma.LogCreateInput = {
         route: '/test',
         method: 'GET',
@@ -56,17 +60,57 @@ describe('LogService', () => {
     });
   });
 
-  describe('findAll', () => {
-    it('should return an array of logs', async () => {
+  describe('findAllPaged', () => {
+    it('should return a paginated object of logs', async () => {
       const logs: Log[] = [
-        { logId: 1, timestamp: new Date(), route: '/test1', method: 'GET', userId: null, details: null },
-        { logId: 2, timestamp: new Date(), route: '/test2', method: 'POST', userId: '1', details: { body: { key: 'value' } } },
+        {
+          logId: 1,
+          timestamp: new Date(),
+          route: '/test1',
+          method: 'GET',
+          userId: null,
+          details: null,
+        },
+        {
+          logId: 2,
+          timestamp: new Date(),
+          route: '/test2',
+          method: 'POST',
+          userId: '1',
+          details: { body: { key: 'value' } },
+        },
       ];
-      mockPrismaService.log.findMany.mockResolvedValue(logs);
+      const total = 2;
+      const page = 1;
+      const limit = 20;
 
-      const result = await service.findAll();
-      expect(result).toEqual(logs);
-      expect(mockPrismaService.log.findMany).toHaveBeenCalled();
+      mockPrismaService.$transaction.mockResolvedValue([total, logs]);
+
+      const result = await service.findAllPaged({ page, limit });
+
+      expect(result).toEqual({
+        data: logs,
+        total,
+        page,
+        limit,
+      });
+
+      expect(mockPrismaService.$transaction).toHaveBeenCalled();
+      expect(mockPrismaService.log.count).toHaveBeenCalled();
+      expect(mockPrismaService.log.findMany).toHaveBeenCalledWith({
+        orderBy: { timestamp: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+        include: {
+          user: {
+            select: {
+              userId: true,
+              name: true,
+              email: true,
+            },
+          },
+        },
+      });
     });
   });
 });

--- a/src/application/log/log.service.ts
+++ b/src/application/log/log.service.ts
@@ -10,7 +10,30 @@ export class LogService {
     return this.prisma.log.create({ data });
   }
 
-  async findAll(): Promise<Log[]> {
-    return this.prisma.log.findMany();
+  async findAllPaged(params: {
+    page: number;
+    limit: number;
+  }): Promise<{ data: Log[]; total: number; page: number; limit: number }> {
+    const { page, limit } = params;
+
+    const [total, data] = await this.prisma.$transaction([
+      this.prisma.log.count(),
+      this.prisma.log.findMany({
+        orderBy: { timestamp: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+        include: {
+          user: {
+            select: {
+              userId: true,
+              name: true,
+              email: true,
+            },
+          },
+        },
+      }),
+    ]);
+
+    return { data, total, page, limit };
   }
 }


### PR DESCRIPTION
- Updated `LogService.findAll` to `LogService.findAllPaged` using Prisma's `skip` and `take`.
- Added `$transaction` to return both data and total count.
- Updated `LogController` to accept `page` and `limit` query parameters with validation.
- Included basic user information in log results for better visibility.
- Updated unit tests to reflect the new paginated structure.

This change prevents unbounded data retrieval from the `logs` table, improving database performance and reducing application memory usage as the table grows.