### PR TITLE
chore: remove unused enableShutdownHooks from PrismaService

### DIFF
--- a/src/core/config/prisma.service.ts
+++ b/src/core/config/prisma.service.ts
@@ -1,15 +1,9 @@
-import { Injectable, OnModuleInit, INestApplication } from '@nestjs/common';
+import { Injectable, OnModuleInit } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit {
   async onModuleInit() {
     await this.$connect();
-  }
-
-  enableShutdownHooks(app: INestApplication) {
-    (this as any).$on('beforeExit', async () => {
-      await app.close();
-    });
   }
 }


### PR DESCRIPTION
Removed the `enableShutdownHooks` method from `PrismaService` as it was identified as dead code. This method used the deprecated Prisma `beforeExit` event and was not called anywhere in the codebase. Following modern NestJS/Prisma best practices, shutdown hooks should be handled at the application level if needed.