### PR TITLE
🔒 fix: remove weak default JWT secret and enforce environment variable

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,7 +5,7 @@ import { PrismaService } from './core/config/prisma.service';
 import { LogModule } from './application/log/log.module';
 import { LoggerMiddleware } from './application/log/middleware/log.middleware';
 import { HomeModule } from './application/home/home.module';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { MailModule } from './core/mail/mail.module';
 import mailConfig from './core/mail/mail.config';
 import { APP_GUARD, APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
@@ -43,10 +43,22 @@ import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
         limit: 5, // 5 tentativas de login por minuto
       },
     ]),
-    JwtModule.register({
+    JwtModule.registerAsync({
       global: true,
-      secret: process.env.JWT_SECRET || 'default-secret',
-      signOptions: { expiresIn: process.env.JWT_ACCESS_TTL || '1h' },
+      imports: [ConfigModule],
+      useFactory: (configService: ConfigService) => {
+        const secret = configService.get<string>('JWT_SECRET');
+        if (!secret) {
+          throw new Error('JWT_SECRET environment variable is not defined');
+        }
+        return {
+          secret: secret,
+          signOptions: {
+            expiresIn: configService.get<string>('JWT_ACCESS_TTL') || '1h',
+          },
+        };
+      },
+      inject: [ConfigService],
     }),
     AuthModule,
     UserModule,

--- a/src/application/auth/auth.service.ts
+++ b/src/application/auth/auth.service.ts
@@ -60,7 +60,9 @@ export class AuthService {
     };
     return this.jwtService.signAsync(payload, {
       expiresIn: this.getRefreshTokenExpiry(),
-      secret: this.configService.get<string>('JWT_REFRESH_SECRET') || (process.env.JWT_SECRET || 'default-secret'),
+      secret:
+        this.configService.get<string>('JWT_REFRESH_SECRET') ||
+        this.configService.get<string>('JWT_SECRET'),
     });
   }
 
@@ -283,8 +285,14 @@ export class AuthService {
 
   async refreshToken(token: string): Promise<{ access_token: string; refresh_token: string }> {
     try {
-      const payload = await this.jwtService.verifyAsync<{ sub: string; tv: number; type: string }>(token, {
-        secret: this.configService.get<string>('JWT_REFRESH_SECRET') || (process.env.JWT_SECRET || 'default-secret'),
+      const payload = await this.jwtService.verifyAsync<{
+        sub: string;
+        tv: number;
+        type: string;
+      }>(token, {
+        secret:
+          this.configService.get<string>('JWT_REFRESH_SECRET') ||
+          this.configService.get<string>('JWT_SECRET'),
       });
       if (payload.type !== 'refresh') {
         throw new UnauthorizedException('Token inválido');


### PR DESCRIPTION
This commit addresses a security vulnerability where the application would fallback to a weak 'default-secret' if the JWT_SECRET environment variable was not provided.

Changes:
- Modified `AppModule` to use `JwtModule.registerAsync`.
- Added validation in `AppModule` to throw an error and fail startup if `JWT_SECRET` is missing.
- Updated `AuthService` to remove 'default-secret' fallback in `signRefreshToken` and `refreshToken` methods.
- Switched to using `ConfigService` for retrieving secrets in `AuthService`.